### PR TITLE
Update binary name for simulator to match one this package builds

### DIFF
--- a/edgetx-companion.spec
+++ b/edgetx-companion.spec
@@ -16,7 +16,8 @@ Source17: https://github.com/microsoft/uf2/archive/d03b585ed780ed51bb0d1e6e8cf23
 Patch1: edgetx-cmake.patch
 Patch2: edgetx-desktop.patch
 Patch4: edgetx-disable-appimage.patch
-Patch5: build-simulator.sh.patch
+Patch5: edgetx-simulator-name.patch
+Patch6: build-simulator.sh.patch
 
 BuildRequires: cmake
 BuildRequires: make

--- a/edgetx-simulator-name.patch
+++ b/edgetx-simulator-name.patch
@@ -1,0 +1,13 @@
+diff --git a/companion/src/helpers.cpp b/companion/src/helpers.cpp
+index e895d9c29..cf49af65c 100644
+--- a/companion/src/helpers.cpp
++++ b/companion/src/helpers.cpp
+@@ -422,7 +422,7 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
+ #elif defined Q_OS_APPLE
+   const QString program = "simulator.dmg";
+ #else
+-  const QString program = QString("simulator%1%2").arg(VERSION_MAJOR).arg(VERSION_MINOR);
++  const QString program = QString("edgetx-simulator");
+ #endif
+ 
+   QStringList arguments;


### PR DESCRIPTION
The source code hardcodes the name of the binary and since this package attempts to strip the verion suffix and adds edgetx- prefix to binaies in creates in CMake, the hardcoded name in source files name should be changed as well.